### PR TITLE
Fix breaking virtual dom by x-select element

### DIFF
--- a/elements/x-overlay.js
+++ b/elements/x-overlay.js
@@ -22,6 +22,7 @@
           will-change: opacity;
           cursor: default;
           background: rgba(0, 0, 0, 0.5);
+          visibility: hidden;
         }
         :host([hidden]) {
           display: none;
@@ -53,6 +54,7 @@
     }
     set ownerElement(ownerElement) {
       this._ownerElement = ownerElement;
+      this.ownerElement.before(this);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -60,9 +62,8 @@
     show(animate = true) {
       this.style.top = "0px";
       this.style.left = "0px";
-      this.ownerElement.before(this);
+      this.style.visibility = 'visible'
       this.hidden = false;
-
       let bounds = this.getBoundingClientRect();
       let extraTop = 0;
       let extraLeft = 0;
@@ -122,14 +123,14 @@
 
         overlayAnimation.finished.then(() => {
           document.body.style.overflow = null;
-          this.remove();
+          this.style.visibility = 'hidden'
         });
 
         return overlayAnimation.finished;
       }
       else {
         document.body.style.overflow = null;
-        this.remove();
+        this.style.visibility = 'hidden'
       }
     }
   }

--- a/elements/x-select.js
+++ b/elements/x-select.js
@@ -190,7 +190,7 @@
 
       this._wasFocusedBeforeExpanding = this.matches(":focus");
 
-      this["#overlay"].show(false);
+      this["#overlay"].style.visibility = 'visible';
 
       window.addEventListener("resize", this._resizeListener = () => {
         this._collapse();
@@ -268,7 +268,7 @@
       let menu = this.querySelector(":scope > x-menu");
       menu.setAttribute("closing", "");
       await whenTriggerEnd;
-      this["#overlay"].hide(false);
+      this["#overlay"].style.visibility = 'hidden';
 
       if (this._wasFocusedBeforeExpanding) {
         this.focus();

--- a/elements/x-select.js
+++ b/elements/x-select.js
@@ -190,7 +190,7 @@
 
       this._wasFocusedBeforeExpanding = this.matches(":focus");
 
-      this["#overlay"].style.visibility = 'visible';
+      this["#overlay"].show(false);
 
       window.addEventListener("resize", this._resizeListener = () => {
         this._collapse();
@@ -268,7 +268,7 @@
       let menu = this.querySelector(":scope > x-menu");
       menu.setAttribute("closing", "");
       await whenTriggerEnd;
-      this["#overlay"].style.visibility = 'hidden';
+      this["#overlay"].hide(false);
 
       if (this._wasFocusedBeforeExpanding) {
         this.focus();


### PR DESCRIPTION
Current version сauses error after first select.

I tested it with [hypperapp](https://github.com/hyperapp/hyperapp), but I think it is rightly for react too.

This happens because `x-overlay` is removed from real DOM by `.hide` method, so renderer lost reference on real node.

This PR should fix this problem. 

What do you think about it?