### PR TITLE
Add _updateEmptyState() to the x-textarea value setter

### DIFF
--- a/elements/x-textarea.js
+++ b/elements/x-textarea.js
@@ -74,6 +74,9 @@ export class XTextareaElement extends HTMLElement {
   }
   set value(value) {
     this["#editor"].textContent = value;
+
+    this.validate();
+    this._updateEmptyState();
   }
 
   // @type


### PR DESCRIPTION
When updating the `value` of an `x-textarea`, the `empty` property was not properly updated.

This pull request adds a call to `_updateEmptyState()` to the value setter to ensure the `empty` property is properly updated.

This also adds a call to `validate()` to mirror the functionality of `x-input`.