### PR TITLE
Update the ownerButtons() getter to use closest()

### DIFF
--- a/elements/x-button.js
+++ b/elements/x-button.js
@@ -76,18 +76,7 @@ export class XButtonElement extends HTMLElement {
   // @type
   //   XButtonsElement?
   get ownerButtons() {
-    if (this.parentElement) {
-      if (this.parentElement.localName === "x-buttons") {
-        return this.parentElement;
-      }
-      else if (this.parentElement.localName === "x-box") {
-        if (this.parentElement.parentElement.localName === "x-buttons") {
-          return this.parentElement.parentElement;
-        }
-      }
-    }
-
-    return null;
+    return this.closest( 'x-buttons' );
   }
 
   // @info


### PR DESCRIPTION
Use `closest()` instead of ad-hoc parent checks to identify any `x-buttons` container.

This avoids errors when a one or more `x-button` elements are contained within an `x-box` at the top-level of a component. In this case, the `x-box` is at the top of the `shadowRoot` and technically has no parent element. This would cause the ad-hoc check to fail at `this.parentElement.parentElement.localName` since `this.parentElement.parentElement` is `null`.
