### PR TITLE
Honor tabindex if set, save it when disabling a component.

### DIFF
--- a/elements/x-button.js
+++ b/elements/x-button.js
@@ -48,9 +48,7 @@ export class XButtonElement extends HTMLElement {
   }
 
   async connectedCallback() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("role", "button");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
 
     if (this.parentElement && this.parentElement.localName === "a" && this.parentElement.tabIndex !== -1) {
       this.parentElement.tabIndex = -1;
@@ -187,8 +185,7 @@ export class XButtonElement extends HTMLElement {
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   _onDisabledAttributeChange() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
   }
 
   _onPointerDown(event) {
@@ -691,6 +688,31 @@ export class XButtonElement extends HTMLElement {
     let menu = this.querySelector("x-menu");
     let popover = this.querySelector("x-popover");
     this["#arrow"].style.display = (menu === null && popover === null) ? "none" : null;
+  }
+
+  _updateAccessabilityAttributes() {
+    let tabIndex  = this.getAttribute('tabindex');
+
+    if (this.disabled) {
+      if (tabIndex >= 0) {
+        // Save the existing 'tabindex' as 'data-tabindex'
+        this.setAttribute('data-tabindex', tabIndex);
+      }
+
+      tabIndex = '-1';
+
+    } else if (this.hasAttribute('data-tabindex')) {
+      // Restore the saved 'tabindex' from 'data-tabindex'
+      tabIndex = this.getAttribute('data-tabindex');
+      this.removeAttribute('data-tabindex');
+
+    } else if (tabIndex == null) {
+      tabIndex = '0';
+    }
+
+    this.setAttribute('tabindex', tabIndex);
+    this.setAttribute("role", "button");
+    this.setAttribute("aria-disabled", this.disabled);
   }
 }
 

--- a/elements/x-button.js
+++ b/elements/x-button.js
@@ -76,18 +76,7 @@ export class XButtonElement extends HTMLElement {
   // @type
   //   XButtonsElement?
   get ownerButtons() {
-    if (this.parentElement) {
-      if (this.parentElement.localName === "x-buttons") {
-        return this.parentElement;
-      }
-      else if (this.parentElement.localName === "x-box") {
-        if (this.parentElement.parentElement.localName === "x-buttons") {
-          return this.parentElement.parentElement;
-        }
-      }
-    }
-
-    return null;
+    return this.closest( 'x-buttons' );
   }
 
   // @info

--- a/elements/x-checkbox.js
+++ b/elements/x-checkbox.js
@@ -40,10 +40,7 @@ export class XCheckboxElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("role", "checkbox");
-    this.setAttribute("aria-checked", this.mixed ? "mixed" : this.toggled);
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
   }
 
   attributeChangedCallback(name) {
@@ -118,8 +115,7 @@ export class XCheckboxElement extends HTMLElement {
   }
 
   _onDisabledAttributeChange() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
   }
 
   _onPointerDown(event) {
@@ -208,6 +204,32 @@ export class XCheckboxElement extends HTMLElement {
       event.preventDefault();
       this.click();
     }
+  }
+
+  _updateAccessabilityAttributes() {
+    let tabIndex  = this.getAttribute('tabindex');
+
+    if (this.disabled) {
+      if (tabIndex >= 0) {
+        // Save the existing 'tabindex' as 'data-tabindex'
+        this.setAttribute('data-tabindex', tabIndex);
+      }
+
+      tabIndex = '-1';
+
+    } else if (this.hasAttribute('data-tabindex')) {
+      // Restore the saved 'tabindex' from 'data-tabindex'
+      tabIndex = this.getAttribute('data-tabindex');
+      this.removeAttribute('data-tabindex');
+
+    } else if (tabIndex == null) {
+      tabIndex = '0';
+    }
+
+    this.setAttribute('tabindex', tabIndex);
+    this.setAttribute("role", "checkbox");
+    this.setAttribute("aria-checked", this.mixed ? "mixed" : this.toggled);
+    this.setAttribute("aria-disabled", this.disabled);
   }
 };
 

--- a/elements/x-colorselect.js
+++ b/elements/x-colorselect.js
@@ -51,8 +51,7 @@ export class XColorSelectElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
 
     let picker = this.querySelector("x-wheelcolorpicker, x-rectcolorpicker");
 
@@ -108,8 +107,7 @@ export class XColorSelectElement extends HTMLElement {
   }
 
   _onDisabledAttributeChange() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
   }
 
   _onChange(event) {
@@ -245,6 +243,30 @@ export class XColorSelectElement extends HTMLElement {
     let [r, g, b, a] = parseColor(this.value, "rgba");
     this["#input"].value = serializeColor([r, g, b, a], "rgba", "hex");
     this["#input"].style.opacity = a;
+  }
+
+  _updateAccessabilityAttributes() {
+    let tabIndex  = this.getAttribute('tabindex');
+
+    if (this.disabled) {
+      if (tabIndex >= 0) {
+        // Save the existing 'tabindex' as 'data-tabindex'
+        this.setAttribute('data-tabindex', tabIndex);
+      }
+
+      tabIndex = '-1';
+
+    } else if (this.hasAttribute('data-tabindex')) {
+      // Restore the saved 'tabindex' from 'data-tabindex'
+      tabIndex = this.getAttribute('data-tabindex');
+      this.removeAttribute('data-tabindex');
+
+    } else if (tabIndex == null) {
+      tabIndex = '0';
+    }
+
+    this.setAttribute('tabindex', tabIndex);
+    this.setAttribute("aria-disabled", this.disabled);
   }
 }
 

--- a/elements/x-input.js
+++ b/elements/x-input.js
@@ -183,9 +183,7 @@ export class XInputElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("role", "input");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
 
     this._updateEmptyState();
   }
@@ -291,9 +289,7 @@ export class XInputElement extends HTMLElement {
   }
 
   _onDisabledAttributeChange() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
-    this["#input"].disabled = this.disabled;
+    this._updateAccessabilityAttributes();
   }
 
   _onFocusIn() {
@@ -340,6 +336,33 @@ export class XInputElement extends HTMLElement {
     else {
       this.removeAttribute("empty");
     }
+  }
+
+  _updateAccessabilityAttributes() {
+    let tabIndex  = this.getAttribute('tabindex');
+
+    if (this.disabled) {
+      if (tabIndex >= 0) {
+        // Save the existing 'tabindex' as 'data-tabindex'
+        this.setAttribute('data-tabindex', tabIndex);
+      }
+
+      tabIndex = '-1';
+
+    } else if (this.hasAttribute('data-tabindex')) {
+      // Restore the saved 'tabindex' from 'data-tabindex'
+      tabIndex = this.getAttribute('data-tabindex');
+      this.removeAttribute('data-tabindex');
+
+    } else if (tabIndex == null) {
+      tabIndex = '0';
+    }
+
+    this.setAttribute('tabindex', tabIndex);
+    this.setAttribute("role", "input");
+    this.setAttribute("aria-disabled", this.disabled);
+
+    this["#input"].disabled = this.disabled;
   }
 }
 

--- a/elements/x-menuitem.js
+++ b/elements/x-menuitem.js
@@ -49,9 +49,7 @@ export class XMenuItemElement extends HTMLElement {
   connectedCallback() {
     this._observer.observe(this, {childList: true, attributes: false, characterData: false, subtree: false});
 
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("role", "menuitem");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
 
     this._update();
   }
@@ -147,8 +145,7 @@ export class XMenuItemElement extends HTMLElement {
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   _onDisabledAttributeChange() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
   }
 
   async _onPointerDown(pointerDownEvent) {
@@ -297,6 +294,31 @@ export class XMenuItemElement extends HTMLElement {
         this["#arrow-icon"].hidden = menu ? false : true;
       }
     }
+  }
+
+  _updateAccessabilityAttributes() {
+    let tabIndex  = this.getAttribute('tabindex');
+
+    if (this.disabled) {
+      if (tabIndex >= 0) {
+        // Save the existing 'tabindex' as 'data-tabindex'
+        this.setAttribute('data-tabindex', tabIndex);
+      }
+
+      tabIndex = '-1';
+
+    } else if (this.hasAttribute('data-tabindex')) {
+      // Restore the saved 'tabindex' from 'data-tabindex'
+      tabIndex = this.getAttribute('data-tabindex');
+      this.removeAttribute('data-tabindex');
+
+    } else if (tabIndex == null) {
+      tabIndex = '0';
+    }
+
+    this.setAttribute('tabindex', tabIndex);
+    this.setAttribute("role", "menuitem");
+    this.setAttribute("aria-disabled", this.disabled);
   }
 }
 

--- a/elements/x-numberinput.js
+++ b/elements/x-numberinput.js
@@ -64,9 +64,7 @@ export class XNumberInputElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("role", "input");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
 
     this._update();
   }
@@ -260,9 +258,7 @@ export class XNumberInputElement extends HTMLElement {
   }
 
   _onDisabledAttributeChange() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
-    this["#editor"].disabled = this.disabled;
+    this._updateAccessabilityAttributes();
   }
 
   _onFocusIn() {
@@ -634,6 +630,32 @@ export class XNumberInputElement extends HTMLElement {
         stepper.setAttribute("disabled", "decrement");
       }
     }
+  }
+
+  _updateAccessabilityAttributes() {
+    let tabIndex  = this.getAttribute('tabindex');
+
+    if (this.disabled) {
+      if (tabIndex >= 0) {
+        // Save the existing 'tabindex' as 'data-tabindex'
+        this.setAttribute('data-tabindex', tabIndex);
+      }
+
+      tabIndex = '-1';
+
+    } else if (this.hasAttribute('data-tabindex')) {
+      // Restore the saved 'tabindex' from 'data-tabindex'
+      tabIndex = this.getAttribute('data-tabindex');
+      this.removeAttribute('data-tabindex');
+
+    } else if (tabIndex == null) {
+      tabIndex = '0';
+    }
+
+    this.setAttribute('tabindex', tabIndex);
+    this.setAttribute("role", "input");
+    this.setAttribute("aria-disabled", this.disabled);
+    this["#editor"].disabled = this.disabled;
   }
 }
 

--- a/elements/x-radio.js
+++ b/elements/x-radio.js
@@ -37,13 +37,7 @@ export class XRadioElement extends HTMLElement {
   }
 
   connectedCallback() {
-    if (!this.closest("x-radios")) {
-      this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    }
-
-    this.setAttribute("role", "radio");
-    this.setAttribute("aria-checked", this.toggled);
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
   }
 
   attributeChangedCallback(name) {
@@ -118,8 +112,7 @@ export class XRadioElement extends HTMLElement {
   }
 
   _onDisabledAttributeChange() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
   }
 
   _onClick(event) {
@@ -154,6 +147,35 @@ export class XRadioElement extends HTMLElement {
       event.preventDefault();
       this.click();
     }
+  }
+
+  _updateAccessabilityAttributes() {
+    if (!this.closest("x-radios")) {
+      let tabIndex  = this.getAttribute('tabindex');
+
+      if (this.disabled) {
+        if (tabIndex >= 0) {
+          // Save the existing 'tabindex' as 'data-tabindex'
+          this.setAttribute('data-tabindex', tabIndex);
+        }
+
+        tabIndex = '-1';
+
+      } else if (this.hasAttribute('data-tabindex')) {
+        // Restore the saved 'tabindex' from 'data-tabindex'
+        tabIndex = this.getAttribute('data-tabindex');
+        this.removeAttribute('data-tabindex');
+
+      } else if (tabIndex == null) {
+        tabIndex = '0';
+      }
+
+      this.setAttribute('tabindex', tabIndex);
+    }
+
+    this.setAttribute("role", "radio");
+    this.setAttribute("aria-checked", this.toggled);
+    this.setAttribute("aria-disabled", this.disabled);
   }
 };
 

--- a/elements/x-select.js
+++ b/elements/x-select.js
@@ -55,7 +55,17 @@ export class XSelectElement extends HTMLElement {
   connectedCallback() {
     this._observer.observe(this, {childList: true, attributes: true, characterData: true, subtree: true});
 
-    this._updateAccessabiltyAttributes();
+    this._updateAccessabilityAttributes();
+
+    let menu = this.querySelector(":scope > x-menu");
+
+    if (menu) {
+      menu.setAttribute("role", "listbox");
+
+      for (let item of menu.querySelectorAll("x-listitem")) {
+        item.setAttribute("role", "option");
+      }
+    }
 
     if (debug) {
       this.setAttribute("debug", "");
@@ -109,8 +119,7 @@ export class XSelectElement extends HTMLElement {
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   _onDisabledAttributeChange() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
   }
 
   _onMutation(records) {
@@ -339,20 +348,29 @@ export class XSelectElement extends HTMLElement {
     this["#button"].append(arrowContainer);
   }
 
-  _updateAccessabiltyAttributes() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
+  _updateAccessabilityAttributes() {
+    let tabIndex  = this.getAttribute('tabindex');
+
+    if (this.disabled) {
+      if (tabIndex >= 0) {
+        // Save the existing 'tabindex' as 'data-tabindex'
+        this.setAttribute('data-tabindex', tabIndex);
+      }
+
+      tabIndex = '-1';
+
+    } else if (this.hasAttribute('data-tabindex')) {
+      // Restore the saved 'tabindex' from 'data-tabindex'
+      tabIndex = this.getAttribute('data-tabindex');
+      this.removeAttribute('data-tabindex');
+
+    } else if (tabIndex == null) {
+      tabIndex = '0';
+    }
+
+    this.setAttribute('tabindex', tabIndex);
     this.setAttribute("role", "button");
     this.setAttribute("aria-disabled", this.disabled);
-
-    let menu = this.querySelector(":scope > x-menu");
-
-    if (menu) {
-      menu.setAttribute("role", "listbox");
-
-      for (let item of menu.querySelectorAll("x-listitem")) {
-        item.setAttribute("role", "option");
-      }
-    }
   }
 }
 

--- a/elements/x-slider.js
+++ b/elements/x-slider.js
@@ -71,9 +71,7 @@ export class XSliderElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
-    this.setAttribute("value", this.value);
+    this._updateAccessabilityAttributes();
 
     this._observer.observe(this, {
       childList: true,
@@ -321,6 +319,31 @@ export class XSliderElement extends HTMLElement {
       label.style.left = (((label.value - this.min) / (this.max - this.min)) * 100) + "%";
       this["#ticks"].insertAdjacentHTML("beforeend", `<div class="tick" style="left: ${label.style.left}"></div>`);
     }
+  }
+
+  _updateAccessabilityAttributes() {
+    let tabIndex  = this.getAttribute('tabindex');
+
+    if (this.disabled) {
+      if (tabIndex >= 0) {
+        // Save the existing 'tabindex' as 'data-tabindex'
+        this.setAttribute('data-tabindex', tabIndex);
+      }
+
+      tabIndex = '-1';
+
+    } else if (this.hasAttribute('data-tabindex')) {
+      // Restore the saved 'tabindex' from 'data-tabindex'
+      tabIndex = this.getAttribute('data-tabindex');
+      this.removeAttribute('data-tabindex');
+
+    } else if (tabIndex == null) {
+      tabIndex = '0';
+    }
+
+    this.setAttribute('tabindex', tabIndex);
+    this.setAttribute("aria-disabled", this.disabled);
+    this.setAttribute("value", this.value);
   }
 }
 

--- a/elements/x-switch.js
+++ b/elements/x-switch.js
@@ -42,10 +42,7 @@ export class XSwitchElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("role", "switch");
-    this.setAttribute("aria-checked", this.mixed ? "mixed" : this.toggled);
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
   }
 
   attributeChangedCallback(name) {
@@ -106,8 +103,7 @@ export class XSwitchElement extends HTMLElement {
   }
 
   _onDisabledAttributeChange() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
   }
 
   _onPointerDown(event) {
@@ -196,6 +192,32 @@ export class XSwitchElement extends HTMLElement {
       event.preventDefault();
       this.click();
     }
+  }
+
+  _updateAccessabilityAttributes() {
+    let tabIndex  = this.getAttribute('tabindex');
+
+    if (this.disabled) {
+      if (tabIndex >= 0) {
+        // Save the existing 'tabindex' as 'data-tabindex'
+        this.setAttribute('data-tabindex', tabIndex);
+      }
+
+      tabIndex = '-1';
+
+    } else if (this.hasAttribute('data-tabindex')) {
+      // Restore the saved 'tabindex' from 'data-tabindex'
+      tabIndex = this.getAttribute('data-tabindex');
+      this.removeAttribute('data-tabindex');
+
+    } else if (tabIndex == null) {
+      tabIndex = '0';
+    }
+
+    this.setAttribute('tabindex', tabIndex);
+    this.setAttribute("role", "switch");
+    this.setAttribute("aria-checked", this.mixed ? "mixed" : this.toggled);
+    this.setAttribute("aria-disabled", this.disabled);
   }
 };
 

--- a/elements/x-taginput.js
+++ b/elements/x-taginput.js
@@ -42,9 +42,7 @@ export class XTagInputElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("role", "input");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
 
     this._update();
   }
@@ -153,8 +151,7 @@ export class XTagInputElement extends HTMLElement {
   }
 
   _onDisabledAttributeChange() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -302,6 +299,31 @@ export class XTagInputElement extends HTMLElement {
     if (placeholder) {
       placeholder.hidden = (this.value.length > 0 || this["#editable-item"].textContent.length > 0);
     }
+  }
+
+  _updateAccessabilityAttributes() {
+    let tabIndex  = this.getAttribute('tabindex');
+
+    if (this.disabled) {
+      if (tabIndex >= 0) {
+        // Save the existing 'tabindex' as 'data-tabindex'
+        this.setAttribute('data-tabindex', tabIndex);
+      }
+
+      tabIndex = '-1';
+
+    } else if (this.hasAttribute('data-tabindex')) {
+      // Restore the saved 'tabindex' from 'data-tabindex'
+      tabIndex = this.getAttribute('data-tabindex');
+      this.removeAttribute('data-tabindex');
+
+    } else if (tabIndex == null) {
+      tabIndex = '0';
+    }
+
+    this.setAttribute('tabindex', tabIndex);
+    this.setAttribute("role", "input");
+    this.setAttribute("aria-disabled", this.disabled);
   }
 };
 

--- a/elements/x-textarea.js
+++ b/elements/x-textarea.js
@@ -144,9 +144,7 @@ export class XTextareaElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("role", "input");
-    this.setAttribute("aria-disabled", this.disabled);
+    this._updateAccessabilityAttributes();
 
     this._updateEmptyState();
   }
@@ -221,9 +219,7 @@ export class XTextareaElement extends HTMLElement {
   }
 
   _onDisabledAttributeChange() {
-    this.setAttribute("tabindex", this.disabled ? "-1" : "0");
-    this.setAttribute("aria-disabled", this.disabled);
-    this["#editor"].disabled = this.disabled;
+    this._updateAccessabilityAttributes();
   }
 
   _onEditorClick(event) {
@@ -267,6 +263,32 @@ export class XTextareaElement extends HTMLElement {
     else {
       this.removeAttribute("empty");
     }
+  }
+
+  _updateAccessabilityAttributes() {
+    let tabIndex  = this.getAttribute('tabindex');
+
+    if (this.disabled) {
+      if (tabIndex >= 0) {
+        // Save the existing 'tabindex' as 'data-tabindex'
+        this.setAttribute('data-tabindex', tabIndex);
+      }
+
+      tabIndex = '-1';
+
+    } else if (this.hasAttribute('data-tabindex')) {
+      // Restore the saved 'tabindex' from 'data-tabindex'
+      tabIndex = this.getAttribute('data-tabindex');
+      this.removeAttribute('data-tabindex');
+
+    } else if (tabIndex == null) {
+      tabIndex = '0';
+    }
+
+    this.setAttribute('tabindex', tabIndex);
+    this.setAttribute("role", "input");
+    this.setAttribute("aria-disabled", this.disabled);
+    this["#editor"].disabled = this.disabled;
   }
 }
 


### PR DESCRIPTION

Add `_updateAccessabilityAttributes()` to components that use `tabindex` for the purpose of managing accessability attributes, including `tabindex`:
- honor any existing `tabindex` attribute on the source component;
- if there is no `tabindex`, initialize it to '0';
- when a component is `disabled`, save the original `tabindex` value in the `data-tabindex` attribute and set `tabindex` to '-1';
- when a component becomes enabled, if there is a `data-tabindex` attribute, restore the `tabindex` value stored there and remove the  `data-tabindex` attribute;