### PR TITLE
Add support for spec-compliant boolean attributes.

### DIFF
--- a/elements/x-select.js
+++ b/elements/x-select.js
@@ -38,7 +38,7 @@ export class XSelectElement extends HTMLElement {
   // @default
   //   null
   get value() {
-    let item = this.querySelector(`x-menuitem[selected="true"]`);
+    let item = this.querySelector(`x-menuitem[selected]:not([selected="false"])`);
     return item ? item.value : null;
   }
   set value(value) {
@@ -142,7 +142,7 @@ export class XSelectElement extends HTMLElement {
         if (item.selected === null) {
           item.selected = false;
         }
-        else if (item.selected === true) {
+        else if (item.selected !== false) {
           if (selectedItem === null) {
             selectedItem = item;
           }
@@ -155,7 +155,7 @@ export class XSelectElement extends HTMLElement {
 
     // Open the menu
     {
-      let selectedItem = menu.querySelector(`x-menuitem[selected="true"]`);
+      let selectedItem = menu.querySelector(`x-menuitem[selected]:not([selected="false"])`);
 
       if (selectedItem) {
         let buttonChild = this["#button"].querySelector("x-label") || this["#button"].firstElementChild;
@@ -243,7 +243,7 @@ export class XSelectElement extends HTMLElement {
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   _updateButton() {
-    let selectedItem = this.querySelector(`:scope > x-menu x-menuitem[selected="true"]`);
+    let selectedItem = this.querySelector(`:scope > x-menu x-menuitem[selected]:not([selected="false"])`);
     this["#button"].innerHTML = "";
 
     if (selectedItem) {

--- a/elements/xel-app.js
+++ b/elements/xel-app.js
@@ -119,7 +119,7 @@ let shadowTemplate = html`
                     <x-label>MacOS</x-label>
                   </x-menuitem>
 
-                  <x-menuitem value="material" selected="true">
+                  <x-menuitem value="material" selected>
                     <x-label>Material</x-label>
                   </x-menuitem>
 
@@ -688,7 +688,7 @@ export class XelAppElement extends HTMLElement {
 
         for (let [colorName, colorValue] of Object.entries(colorSchemesByTheme[themeName])) {
           itemsHTML += `
-            <x-menuitem value="${colorName}" selected="true">
+            <x-menuitem value="${colorName}" selected>
               <x-swatch value="${colorValue}"></x-swatch>
               <x-label>${capitalize(colorName)}</x-label>
             </x-menuitem>


### PR DESCRIPTION
When using boolean attributes, [the spec](http://w3c.github.io/html/infrastructure.html#sec-boolean-attributes) states:
> [2.4.2. Boolean attributes](http://w3c.github.io/html/infrastructure.html#sec-boolean-attributes)
> A number of attributes are boolean attributes. The presence of a boolean attribute on an element 
> represents the true value, and the absence of the attribute represents the false value.
>
> If the attribute is present, its value must either be the empty string or a value that is an ASCII case-
> insensitive match for the attribute’s canonical name, with no leading or trailing white space.

For `x-select`, xel was using the literal string `true` when searching for the currently selected item. This misses the selected item when using attribute presence/absence to indicate the boolean value.

This pull request should allow for both usages -- attribute presence/absence or an attribute with an explicit value that is not `false`.

