### PR TITLE
Add a 'checkable' attribute to x-menuitem

### DIFF
--- a/docs/x-accordion.html
+++ b/docs/x-accordion.html
@@ -85,7 +85,7 @@
               <main>
                 <x-select style="width: 100%;">
                   <x-menu>
-                    <x-menuitem selected="true"><x-label>Solid</x-label></x-menuitem>
+                    <x-menuitem selected><x-label>Solid</x-label></x-menuitem>
                     <x-menuitem><x-label>Linear Gradient</x-label></x-menuitem>
                     <x-menuitem><x-label>Radial Gradient</x-label></x-menuitem>
                   </x-menu>

--- a/docs/x-menubar.html
+++ b/docs/x-menubar.html
@@ -81,11 +81,11 @@
                 <x-label>View</x-label>
 
                 <x-menu>
-                  <x-menuitem selected="true">
+                  <x-menuitem checkable selected>
                     <x-label>Show ruler</x-label>
                   </x-menuitem>
 
-                  <x-menuitem selected="false">
+                  <x-menuitem checkable>
                     <x-label>Show spelling suggestions</x-label>
                   </x-menuitem>
                 </x-menu>
@@ -257,7 +257,7 @@
                 <x-label>View</x-label>
 
                 <x-menu>
-                  <x-menuitem selected="true">
+                  <x-menuitem selected>
                     <x-label>Print layout</x-label>
                   </x-menuitem>
 
@@ -285,26 +285,26 @@
 
                   <hr/>
 
-                  <x-menuitem selected="true">
+                  <x-menuitem checkable selected>
                     <x-label>Show ruler</x-label>
                   </x-menuitem>
 
-                  <x-menuitem selected="false">
+                  <x-menuitem checkable >
                     <x-label>Show equation toolbar</x-label>
                   </x-menuitem>
 
-                  <x-menuitem selected="true">
+                  <x-menuitem checkable selected>
                     <x-label>Show spelling suggestions</x-label>
                   </x-menuitem>
 
                   <hr/>
 
-                  <x-menuitem selected="false">
+                  <x-menuitem checkable>
                     <x-label>Compact controls</x-label>
                     <x-shortcut value="Control+Shift+F"></x-shortcut>
                   </x-menuitem>
 
-                  <x-menuitem selected="false">
+                  <x-menuitem checkable>
                     <x-label>Full screen</x-label>
                   </x-menuitem>
                 </x-menu>
@@ -440,15 +440,15 @@
                     <x-label>Columns</x-label>
 
                     <x-menu>
-                      <x-menuitem selected="true">
+                      <x-menuitem checkable selected>
                         <x-label>1</x-label>
                       </x-menuitem>
 
-                      <x-menuitem selected="false">
+                      <x-menuitem checkable>
                         <x-label>2</x-label>
                       </x-menuitem>
 
-                      <x-menuitem selected="false">
+                      <x-menuitem checkable>
                         <x-label>3</x-label>
                       </x-menuitem>
 

--- a/docs/x-menubar.html
+++ b/docs/x-menubar.html
@@ -81,11 +81,11 @@
                 <x-label>View</x-label>
 
                 <x-menu>
-                  <x-menuitem checkable selected>
+                  <x-menuitem togglable selected>
                     <x-label>Show ruler</x-label>
                   </x-menuitem>
 
-                  <x-menuitem checkable>
+                  <x-menuitem togglable>
                     <x-label>Show spelling suggestions</x-label>
                   </x-menuitem>
                 </x-menu>
@@ -285,26 +285,26 @@
 
                   <hr/>
 
-                  <x-menuitem checkable selected>
+                  <x-menuitem togglable selected>
                     <x-label>Show ruler</x-label>
                   </x-menuitem>
 
-                  <x-menuitem checkable >
+                  <x-menuitem togglable >
                     <x-label>Show equation toolbar</x-label>
                   </x-menuitem>
 
-                  <x-menuitem checkable selected>
+                  <x-menuitem togglable selected>
                     <x-label>Show spelling suggestions</x-label>
                   </x-menuitem>
 
                   <hr/>
 
-                  <x-menuitem checkable>
+                  <x-menuitem togglable>
                     <x-label>Compact controls</x-label>
                     <x-shortcut value="Control+Shift+F"></x-shortcut>
                   </x-menuitem>
 
-                  <x-menuitem checkable>
+                  <x-menuitem togglable>
                     <x-label>Full screen</x-label>
                   </x-menuitem>
                 </x-menu>
@@ -440,15 +440,15 @@
                     <x-label>Columns</x-label>
 
                     <x-menu>
-                      <x-menuitem checkable selected>
+                      <x-menuitem togglable selected>
                         <x-label>1</x-label>
                       </x-menuitem>
 
-                      <x-menuitem checkable>
+                      <x-menuitem togglable>
                         <x-label>2</x-label>
                       </x-menuitem>
 
-                      <x-menuitem checkable>
+                      <x-menuitem togglable>
                         <x-label>3</x-label>
                       </x-menuitem>
 

--- a/docs/x-menuitem.html
+++ b/docs/x-menuitem.html
@@ -76,16 +76,16 @@
       <hr/>
 
       <section>
-        <h4>Selected</h4>
+        <h4>Check mark</h4>
 
         <xel-demo>
           <template>
             <x-menu opened>
-              <x-menuitem selected="true">
+              <x-menuitem checkable selected>
                 <x-label>Small</x-label>
               </x-menuitem>
 
-              <x-menuitem selected="false">
+              <x-menuitem checkable>
                 <x-label>Medium</x-label>
               </x-menuitem>
             </x-menu>

--- a/docs/x-menuitem.html
+++ b/docs/x-menuitem.html
@@ -81,11 +81,11 @@
         <xel-demo>
           <template>
             <x-menu opened>
-              <x-menuitem checkable selected>
+              <x-menuitem togglable selected>
                 <x-label>Small</x-label>
               </x-menuitem>
 
-              <x-menuitem checkable>
+              <x-menuitem togglable>
                 <x-label>Medium</x-label>
               </x-menuitem>
             </x-menu>

--- a/docs/x-select.html
+++ b/docs/x-select.html
@@ -16,7 +16,7 @@
                   <x-label>Australia</x-label>
                 </x-menuitem>
 
-                <x-menuitem value="canada" selected="true">
+                <x-menuitem value="canada" selected>
                   <x-label>Canada</x-label>
                 </x-menuitem>
 
@@ -62,7 +62,7 @@
                   <x-icon name="flight"></x-icon>
                 </x-menuitem>
 
-                <x-menuitem value="car" selected="true">
+                <x-menuitem value="car" selected>
                   <x-icon name="directions-car"></x-icon>
                 </x-menuitem>
 
@@ -94,7 +94,7 @@
                   <x-label>Bike</x-label>
                 </x-menuitem>
 
-                <x-menuitem value="plane" selected="true">
+                <x-menuitem value="plane" selected>
                   <x-icon name="flight"></x-icon>
                   <x-label>Plane</x-label>
                 </x-menuitem>
@@ -123,7 +123,7 @@
           <template>
             <x-select>
               <x-menu>
-                <x-menuitem value="red" selected="true">
+                <x-menuitem value="red" selected>
                   <x-swatch value="#F44336"></x-swatch>
                   <x-label>Red</x-label>
                 </x-menuitem>
@@ -164,7 +164,7 @@
           <template>
             <x-select>
               <x-menu>
-                <x-menuitem value="red" selected="true">
+                <x-menuitem value="red" selected>
                   <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEXnNzcjbf7EAAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg==">
                   <x-label>Red</x-label>
                 </x-menuitem>
@@ -217,7 +217,7 @@
           <template>
             <x-select>
               <x-menu>
-                <x-menuitem value="plane" selected="true">
+                <x-menuitem value="plane" selected>
                   <x-icon name="flight"></x-icon>
                   <x-label>Plane</x-label>
                 </x-menuitem>
@@ -236,7 +236,7 @@
           <template>
             <x-select disabled>
               <x-menu>
-                <x-menuitem value="train" selected="true">
+                <x-menuitem value="train" selected>
                   <x-icon name="directions-railway"></x-icon>
                   <x-label>Train</x-label>
                 </x-menuitem>
@@ -260,7 +260,7 @@
           <template>
             <x-select>
               <x-menu>
-                <x-menuitem value="train" selected="true">
+                <x-menuitem value="train" selected>
                   <x-icon name="directions-railway"></x-icon>
                   <x-label>Train</x-label>
                 </x-menuitem>
@@ -284,7 +284,7 @@
           <template>
             <x-select style="width: 100%;">
               <x-menu>
-                <x-menuitem value="train" selected="true">
+                <x-menuitem value="train" selected>
                   <x-icon name="directions-railway"></x-icon>
                   <x-label>Train</x-label>
                 </x-menuitem>
@@ -308,7 +308,7 @@
           <template>
             <x-select style="width: 125px;">
               <x-menu>
-                <x-menuitem value="incomprehensible" selected="true">
+                <x-menuitem value="incomprehensible" selected>
                   <x-icon name="directions-railway"></x-icon>
                   <x-label>Incomprehensible</x-label>
                 </x-menuitem>
@@ -347,7 +347,7 @@
                   <x-label>Bike</x-label>
                 </x-menuitem>
 
-                <x-menuitem value="plane" selected="true">
+                <x-menuitem value="plane" selected>
                   <x-icon name="flight"></x-icon>
                   <x-label>Plane</x-label>
                 </x-menuitem>
@@ -374,7 +374,7 @@
           <template>
             <x-select skin="flat">
               <x-menu>
-                <x-menuitem value="plane" selected="true">
+                <x-menuitem value="plane" selected>
                   <x-icon name="flight"></x-icon>
                   <x-label>Plane</x-label>
                 </x-menuitem>

--- a/elements/x-menuitem.js
+++ b/elements/x-menuitem.js
@@ -52,26 +52,20 @@ export class XMenuItemElement extends HTMLElement {
   // @default
   //   null
   get selected() {
-    if (this.hasAttribute("selected") === false) {
-      return null;
-    }
-    else if (this.getAttribute("selected") === "false") {
-      return false;
+    if (this.hasAttribute("selected")) {
+      return true;
     }
     else {
-      return true;
+      return false;
     }
   }
   set selected(selected) {
     if (this.selected !== selected) {
-      if (selected === null) {
+      if (! selected) {
         this.removeAttribute("selected");
       }
-      else if (selected === false) {
-        this.setAttribute("selected", "false");
-      }
       else {
-        this.setAttribute("selected", "true");
+        this.setAttribute("selected", "");
       }
     }
   }

--- a/elements/x-select.js
+++ b/elements/x-select.js
@@ -38,12 +38,12 @@ export class XSelectElement extends HTMLElement {
   // @default
   //   null
   get value() {
-    let item = this.querySelector(`x-menuitem[selected="true"]`);
+    let item = this.querySelector(`x-menuitem[selected]`);
     return item ? item.value : null;
   }
   set value(value) {
     for (let item of this.querySelectorAll("x-menuitem")) {
-      item.selected = (item.value === value && value !== null);
+      item.selected = (item.value === value && value != null);
     }
   }
 
@@ -139,10 +139,10 @@ export class XSelectElement extends HTMLElement {
       let selectedItem = null;
 
       for (let item of menu.querySelectorAll("x-menuitem")) {
-        if (item.selected === null) {
+        if (item.selected !== true) {
           item.selected = false;
         }
-        else if (item.selected === true) {
+        else {
           if (selectedItem === null) {
             selectedItem = item;
           }
@@ -155,7 +155,7 @@ export class XSelectElement extends HTMLElement {
 
     // Open the menu
     {
-      let selectedItem = menu.querySelector(`x-menuitem[selected="true"]`);
+      let selectedItem = menu.querySelector(`x-menuitem[selected]`);
 
       if (selectedItem) {
         let buttonChild = this["#button"].querySelector("x-label") || this["#button"].firstElementChild;
@@ -243,7 +243,7 @@ export class XSelectElement extends HTMLElement {
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   _updateButton() {
-    let selectedItem = this.querySelector(`:scope > x-menu x-menuitem[selected="true"]`);
+    let selectedItem = this.querySelector(`:scope > x-menu x-menuitem[selected]`);
     this["#button"].innerHTML = "";
 
     if (selectedItem) {
@@ -322,6 +322,12 @@ export class XSelectElement extends HTMLElement {
     for (let record of records) {
       if (record.type === "attributes" && record.target.localName === "x-menuitem" && record.attributeName === "selected") {
         this._updateButtonTh300();
+      }
+      if (record.type === "childList" && record.target.localName === "x-menu") {
+        // Ensure that all 'x-menuitem' children have the 'checkable' attribute
+        for (let item of record.target.querySelectorAll('x-menuitem:not([checkable])')) {
+          item.setAttribute("checkable", "");
+        }
       }
     }
   }

--- a/elements/x-select.js
+++ b/elements/x-select.js
@@ -324,9 +324,9 @@ export class XSelectElement extends HTMLElement {
         this._updateButtonTh300();
       }
       if (record.type === "childList" && record.target.localName === "x-menu") {
-        // Ensure that all 'x-menuitem' children have the 'checkable' attribute
-        for (let item of record.target.querySelectorAll('x-menuitem:not([checkable])')) {
-          item.setAttribute("checkable", "");
+        // Ensure that all 'x-menuitem' children have the 'togglable' attribute
+        for (let item of record.target.querySelectorAll('x-menuitem:not([togglable])')) {
+          item.setAttribute("togglable", "");
         }
       }
     }

--- a/stylesheets/x-menuitem.css
+++ b/stylesheets/x-menuitem.css
@@ -80,12 +80,12 @@
   margin: var(--checkmark-margin);
   d: var(--checkmark-d);
 }
-:host([checkable]) #checkmark {
+:host([togglable]) #checkmark {
   display: flex;
   transform: scale(0);
   transform-origin: 50% 50%;
 }
-:host([checkable][selected]) #checkmark {
+:host([togglable][selected]) #checkmark {
   display: flex;
   transform: scale(1);
 }

--- a/stylesheets/x-menuitem.css
+++ b/stylesheets/x-menuitem.css
@@ -80,12 +80,12 @@
   margin: var(--checkmark-margin);
   d: var(--checkmark-d);
 }
-:host([selected]) #checkmark {
+:host([checkable]) #checkmark {
   display: flex;
   transform: scale(0);
   transform-origin: 50% 50%;
 }
-:host([selected="true"]) #checkmark {
+:host([checkable][selected]) #checkmark {
   display: flex;
   transform: scale(1);
 }


### PR DESCRIPTION
This is an alternative for pull request #58 

Add a `checkable` attribute to `<x-menuitem>` to support its use within `<x-select>`.

Update `<x-menuitem>` and `<x-select>` to treat the `selected` attribute as a boolean attribute.

Update `x-select._onMutation()` to check for a 'childList' record with an 'x-menu' target. In this case, ensure that all 'x-menuitem' children of the target include a `checkable` attribute to enable the checkmark functionality of `<x-menuitem>` required by `<x-select>`;