### PR TITLE
Add support for max-height with scrolling on overflow.

### DIFF
--- a/stylesheets/x-textarea.css
+++ b/stylesheets/x-textarea.css
@@ -57,6 +57,8 @@
   flex-flow: column;
   height: 100%;
   min-height: inherit;
+  max-height: inherit;
+  overflow-y: auto;
 }
 
 #editor {


### PR DESCRIPTION
This allows a component user to set `max-height` on the `<x-textarea>` element and have that limit honored within the component.