### PR TITLE
Support a 'no-auto-select' attribute in `<x-input>`

### DIFF
--- a/elements/x-input.js
+++ b/elements/x-input.js
@@ -51,7 +51,7 @@ export class XInputElement extends HTMLElement {
   }
   set value(value) {
     if (this["#input"].value !== value) {
-      if (this.matches(":focus")) {
+      if (this.matches(":focus") && ! this.hasAttribute('no-auto-select')) {
         // https://goo.gl/s1UnHh
         this["#input"].selectionStart = 0;
         this["#input"].selectionEnd = this["#input"].value.length;
@@ -325,7 +325,7 @@ export class XInputElement extends HTMLElement {
   _onValueAttributeChange() {
     this.value = this.hasAttribute("value") ? this.getAttribute("value") : "";
 
-    if (this.matches(":focus")) {
+    if (this.matches(":focus") && ! this.hasAttribute('no-auto-select')) {
       this.selectAll();
     }
   }


### PR DESCRIPTION
Add support for a `no-auto-select` attribute on `<x-input>` to allow disabling auto-select on value change.

This allows the use of `<x-input>` in components that need tighter control of focus, value-change, and selection.
