### PR TITLE
Allow x-popover to use opacity for opening animation.

### DIFF
--- a/elements/x-popover.js
+++ b/elements/x-popover.js
@@ -456,6 +456,9 @@ export class XPopoverElement extends HTMLElement {
             { duration, easing }
           ).finished;
         }
+        else if (property === "opacity") {
+          await this.animate({ opacity: ["0", "1"] }, { duration, easing }).finished;
+        }
       }
 
       this.dispatchEvent(new CustomEvent("open", {bubbles: true, detail: this}));


### PR DESCRIPTION
Allow `<x-popover>` to use `opacity` for the opening animation instead of limiting it to `transform` only.
