### PR TITLE
Route all x-doctabs tab switching to this.selectTab(tab).

### DIFF
--- a/elements/x-doctabs.js
+++ b/elements/x-doctabs.js
@@ -216,11 +216,7 @@ export class XDocTabsElement extends HTMLElement {
     let previousTab = this._getPreviousTabOnScreen(currentTab);
 
     if (currentTab && previousTab) {
-      currentTab.tabIndex = -1;
-      currentTab.selected = false;
-
-      previousTab.tabIndex = 0;
-      previousTab.selected = true;
+      this.selectTab(previousTab);
 
       return previousTab;
     }
@@ -234,16 +230,28 @@ export class XDocTabsElement extends HTMLElement {
     let nextTab = this._getNextTabOnScreen(currentTab);
 
     if (currentTab && nextTab) {
-      currentTab.tabIndex = -1;
-      currentTab.selected = false;
-
-      nextTab.tabIndex = 0;
-      nextTab.selected = true;
+      this.selectTab(nextTab);
 
       return nextTab;
     }
 
     return null;
+  }
+
+  selectTab(nextTab) {
+    let currentTab = this.querySelector(`x-doctab[selected]`) || this.querySelector("x-doctab:last-of-type");
+
+    if (currentTab) {
+      currentTab.tabIndex = -1;
+      currentTab.selected = false;
+    }
+
+    nextTab.tabIndex = 0;
+    nextTab.selected = true;
+
+    if (currentTab != nextTab) {
+      this.dispatchEvent(new CustomEvent("select", {detail: nextTab}));
+    }
   }
 
   moveSelectedTabLeft() {
@@ -526,19 +534,7 @@ export class XDocTabsElement extends HTMLElement {
     let pointerDownTab = pointerDownEvent.target.closest("x-doctab");
     let selectedTab = this.querySelector("x-doctab[selected]");
 
-    for (let tab of this.querySelectorAll("x-doctab")) {
-      if (tab === pointerDownTab) {
-        if (tab.selected === false) {
-          tab.selected = true;
-          this.dispatchEvent(new CustomEvent("select"));
-        }
-      }
-      else {
-        tab.selected = false;
-      }
-
-      tab.tabIndex = (tab === pointerDownTab) ? 0 : -1;
-    }
+    this.selectTab(pointerDownTab);
 
     let selectionIndicatorAnimation = this._animateSelectionIndicator(selectedTab, pointerDownTab);
     this.setPointerCapture(pointerDownEvent.pointerId);
@@ -683,9 +679,7 @@ export class XDocTabsElement extends HTMLElement {
         openedTab.style.order = this.childElementCount;
         this.openTab(openedTab);
 
-        for (let tab of this.children) {
-          tab.selected = (tab === openedTab);
-        }
+        this.selectTab(openedTab);
       }
     }
   }
@@ -703,8 +697,7 @@ export class XDocTabsElement extends HTMLElement {
       currentTab.click();
 
       if (currentTab !== selectedTab) {
-        selectedTab.selected = false;
-        currentTab.selected = true;
+        this.selectTab(currentTab);
         this._animateSelectionIndicator(selectedTab, currentTab);
       }
     }


### PR DESCRIPTION
selectTab(tab) also fires the event. This will make it so _any_ tab selection behavior sends an event (rather than just the pointer down).

The event was also modified to include the selected tab in the event detail.

This is also a useful external API to have.


I found that relying on the select event wasn't super reliable as it only fired in one circumstance. The other times where the tab could be selected weren't able to be captured through events.