### PR TITLE
Fix for relative path icons (Electron specific)

### DIFF
--- a/elements/x-icon.js
+++ b/elements/x-icon.js
@@ -43,30 +43,30 @@ let shadowTemplate = html`
 let cache = {};
 
 export class XIconElement extends HTMLElement {
-    static get observedAttributes() {
-        return ["name", "iconset"];
-    }
+  static get observedAttributes() {
+    return ["name", "iconset"];
+  }
 
-    // @type
-    //   string
-    // @default
-    //   ""
-    // @attribute
-    get name() {
-        return this.hasAttribute("name") ? this.getAttribute("name") : "";
-    }
-    set name(name) {
-        this.setAttribute("name", name);
-    }
+  // @type
+  //   string
+  // @default
+  //   ""
+  // @attribute
+  get name() {
+    return this.hasAttribute("name") ? this.getAttribute("name") : "";
+  }
+  set name(name) {
+    this.setAttribute("name", name);
+  }
 
-    // @type
-    //   string
-    // @default
-    //   "node_modules/xel/images/icons.svg"
-    // @attribute
-    get iconset() {
-        if (this.hasAttribute("iconset") === false || this.getAttribute("iconset").trim() === "") {
-            let userAgent = navigator.userAgent.toLowerCase();
+  // @type
+  //   string
+  // @default
+  //   "node_modules/xel/images/icons.svg"
+  // @attribute
+  get iconset() {
+    if (this.hasAttribute("iconset") === false || this.getAttribute("iconset").trim() === "") {
+      let userAgent = navigator.userAgent.toLowerCase();
             if (userAgent.indexOf(' electron/') > -1) {
                 // electron specific code
                 const electron = require('electron');
@@ -76,116 +76,116 @@ export class XIconElement extends HTMLElement {
             } else {
                 return "node_modules/xel/images/icons.svg";
             }
+    }
+    else {
+      return this.getAttribute("iconset");
+    }
+  }
+  set iconset(iconset) {
+    this.setAttribute("iconset", iconset);
+  }
+
+  // @type
+  //   boolean
+  // @default
+  //   false
+  // @attribute
+  get disabled() {
+    return this.hasAttribute("disabled");
+  }
+  set disabled(disabled) {
+    disabled ? this.setAttribute("disabled", "") : this.removeAttribute("disabled");
+  }
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  constructor() {
+    super();
+
+    this._shadowRoot = this.attachShadow({mode: "closed"});
+    this._shadowRoot.append(document.importNode(shadowTemplate.content, true));
+
+    for (let element of this._shadowRoot.querySelectorAll("[id]")) {
+      this["#" + element.id] = element;
+    }
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (oldValue === newValue) {
+      return;
+    }
+    else if (name === "name") {
+      this._update();
+    }
+    else if (name === "iconset") {
+      this._update();
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  async _update() {
+    if (this.name === "") {
+      this["#svg"].innerHTML = "";
+    }
+    else {
+      let symbol = await this._getSymbol(this.name, this.iconset);
+
+      if (symbol) {
+        this["#svg"].setAttribute("viewBox", symbol.getAttribute("viewBox"));
+        this["#svg"].innerHTML = symbol.innerHTML;
+      }
+      else {
+        this["#svg"].innerHTML = "";
+      }
+    }
+  }
+
+  _getSymbol(name, iconsetURL) {
+    return new Promise(async (resolve) => {
+      let iconset = await this._getIconset(iconsetURL);
+      let symbol = null;
+
+      if (iconset) {
+        symbol = iconset.querySelector("#" + CSS.escape(name));
+      }
+
+      resolve(symbol);
+    });
+  }
+
+  _getIconset(iconsetURL) {
+    return new Promise(async (resolve) => {
+      if (cache[iconsetURL]) {
+        if (cache[iconsetURL].iconset) {
+          resolve(cache[iconsetURL].iconset);
         }
         else {
-            return this.getAttribute("iconset");
+          cache[iconsetURL].callbacks.push(resolve);
         }
-    }
-    set iconset(iconset) {
-        this.setAttribute("iconset", iconset);
-    }
+      }
+      else {
+        cache[iconsetURL] = {callbacks: [resolve], iconset: null};
 
-    // @type
-    //   boolean
-    // @default
-    //   false
-    // @attribute
-    get disabled() {
-        return this.hasAttribute("disabled");
-    }
-    set disabled(disabled) {
-        disabled ? this.setAttribute("disabled", "") : this.removeAttribute("disabled");
-    }
+        let iconsetSVG = null;
 
-    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-    constructor() {
-        super();
-
-        this._shadowRoot = this.attachShadow({mode: "closed"});
-        this._shadowRoot.append(document.importNode(shadowTemplate.content, true));
-
-        for (let element of this._shadowRoot.querySelectorAll("[id]")) {
-            this["#" + element.id] = element;
+        try {
+          iconsetSVG = await readFile(iconsetURL);
         }
-    }
-
-    attributeChangedCallback(name, oldValue, newValue) {
-        if (oldValue === newValue) {
-            return;
+        catch (error) {
+          iconsetSVG = null;
         }
-        else if (name === "name") {
-            this._update();
+
+        if (iconsetSVG) {
+          cache[iconsetURL].iconset = svg`${iconsetSVG}`;
+
+          for (let callback of cache[iconsetURL].callbacks) {
+            callback(cache[iconsetURL].iconset);
+          }
         }
-        else if (name === "iconset") {
-            this._update();
-        }
-    }
-
-    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-    async _update() {
-        if (this.name === "") {
-            this["#svg"].innerHTML = "";
-        }
-        else {
-            let symbol = await this._getSymbol(this.name, this.iconset);
-
-            if (symbol) {
-                this["#svg"].setAttribute("viewBox", symbol.getAttribute("viewBox"));
-                this["#svg"].innerHTML = symbol.innerHTML;
-            }
-            else {
-                this["#svg"].innerHTML = "";
-            }
-        }
-    }
-
-    _getSymbol(name, iconsetURL) {
-        return new Promise(async (resolve) => {
-            let iconset = await this._getIconset(iconsetURL);
-            let symbol = null;
-
-            if (iconset) {
-                symbol = iconset.querySelector("#" + CSS.escape(name));
-            }
-
-            resolve(symbol);
-        });
-    }
-
-    _getIconset(iconsetURL) {
-        return new Promise(async (resolve) => {
-            if (cache[iconsetURL]) {
-                if (cache[iconsetURL].iconset) {
-                    resolve(cache[iconsetURL].iconset);
-                }
-                else {
-                    cache[iconsetURL].callbacks.push(resolve);
-                }
-            }
-            else {
-                cache[iconsetURL] = {callbacks: [resolve], iconset: null};
-
-                let iconsetSVG = null;
-
-                try {
-                    iconsetSVG = await readFile(iconsetURL);
-                }
-                catch (error) {
-                    iconsetSVG = null;
-                }
-
-                if (iconsetSVG) {
-                    cache[iconsetURL].iconset = svg`${iconsetSVG}`;
-
-                    for (let callback of cache[iconsetURL].callbacks) {
-                        callback(cache[iconsetURL].iconset);
-                    }
-                }
-            }
-        });
-    }
+      }
+    });
+  }
 }
 
 customElements.define("x-icon", XIconElement);


### PR DESCRIPTION
Xel Toolkit is an awesome UI toolkit for creating the native desktop-like look and feel in electron apps. The only issue that I came across it is while having a different folder structure of electron app. So when your electron app's folder structure is different (i.e. customized) the icons were not loading due to the relative path. Here is a small snippet of code that I have written to overcome this bug.

**This bug fix will give electron users an option to use this wonderful toolkit while maintaining their folder structure :)**

Few details:-
**Also works when you build the electron app!**

- icons were not loading due to the relative path if your electron folder structure is different (i.e. customized)
- fixed using a small electron specific code which only executes if the toolkit is used in electron
- rest of the code is untouched
- we are requiring electron directly here because the code is electron specific, so electron will be by default present in the node_modules of the user & hence by using app object (available in electron framework ) generating an absolute path
- I have tested this by serving the electron app and the building it (i.e. by creating Debian package and installing)
- requires no additional dependencies