### PR TITLE
Update base.css to fix extra margin in vertically stacked icon and label

### DIFF
--- a/themes/base.css
+++ b/themes/base.css
@@ -779,6 +779,9 @@ x-tab x-label {
 x-tab x-icon + x-label {
   margin-left: 6px;
 }
+x-tab x-box:is([vertical]) x-icon + x-label {
+  margin-left: 0px;
+}
 
 /*****************************************************************************************************************/
 


### PR DESCRIPTION
The margin-left is added to separate icons and labels placed in the same tab. However, if stacking them in the tab vertically by using an x-box in between, the extra margin skews the alignment. This adds an extra rule to revert the extra margin in this situation.